### PR TITLE
Fixed file paths in the highres and lowres config

### DIFF
--- a/highres/theme.conf
+++ b/highres/theme.conf
@@ -10,17 +10,17 @@
 #
 
 # Load banner and fit to screen
-banner themes/refind-dreary/background.png
+banner themes/refind-dreary/highres/background.png
 banner_scale fillscreen
 
 # Load icons
 big_icon_size 256
 small_icon_size 64
-icons_dir themes/refind-dreary/icons
+icons_dir themes/refind-dreary/highres/icons
 
 # Load selection background
-selection_big themes/refind-dreary/selection_big.png
-selection_small themes/refind-dreary/selection_small.png
+selection_big themes/refind-dreary/highres/selection_big.png
+selection_small themes/refind-dreary/highres/selection_small.png
 
 # Hide everything
 hideui singleuser,hints,arrows,label,badges

--- a/lowres/theme.conf
+++ b/lowres/theme.conf
@@ -10,17 +10,17 @@
 #
 
 # Load banner and fit to screen
-banner themes/refind-dreary/background.png
+banner themes/refind-dreary/lowres/background.png
 banner_scale fillscreen
 
 # Load icons
 big_icon_size 128
 small_icon_size 32
-icons_dir themes/refind-dreary/icons
+icons_dir themes/refind-dreary/lowres/icons
 
 # Load selection background
-selection_big themes/refind-dreary/selection_big.png
-selection_small themes/refind-dreary/selection_small.png
+selection_big themes/refind-dreary/lowres/selection_big.png
+selection_small themes/refind-dreary/lowres/selection_small.png
 
 # Hide everything
 hideui singleuser,hints,arrows,label,badges


### PR DESCRIPTION
Today I cloned this repo in the themes folder and followed the instructions in the README, but the background and the icons didn't load. After a bit I figured out that it was because of the wrong file paths in the highres and lowres config.
This fixes the problem by correcting the file paths in the config. 