### PR TITLE
Fixed a bug in the installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ This is a fork with an added readme for a description, as well as instructions f
 ### Automatic installation instructions (Unix based OS only, like Mac and Linux)
 <b>1.</b> Locate your rEFInd EFI directory. This is commonly <code>/boot/EFI/refind</code>, though it will depend on where you mount your ESP and where rEFInd is installed. <code>fdisk -l</code> and <code>mount</code> may help you find it.
 
-<b>2.</b> Copy this repository in the rEFInd directory. For example you can <code>git clone https://github.com/dheishman/refind-dreary.git</code>.
-
-<b>3.</b> Enter the folder containing the theme and execute the installar <code>./install.sh -resolution-</code>.
+<b>2.</b> Copy this repository on your system and execute the installation script(it takes the resolution and the rEFInd directory as arguments). For example you can:
+<code>git clone https://github.com/dheishman/refind-dreary.git && ./refind-dreary/install.sh -resolution- -rEFInd_directory-</code>.
 
 ### Manual installation instructions
 <b>1.</b> Locate your rEFInd EFI directory. This is commonly <code>/boot/EFI/refind</code>, though it will depend on where you mount your ESP and where rEFInd is installed. <code>fdisk -l</code> and <code>mount</code> may help you find it.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a fork with an added readme for a description, as well as instructions f
 <b>1.</b> Locate your rEFInd EFI directory. This is commonly <code>/boot/EFI/refind</code>, though it will depend on where you mount your ESP and where rEFInd is installed. <code>fdisk -l</code> and <code>mount</code> may help you find it.
 
 <b>2.</b> Copy this repository on your system and execute the installation script(it takes the resolution and the rEFInd directory as arguments). For example you can:
+
 <code>git clone https://github.com/dheishman/refind-dreary.git && ./refind-dreary/install.sh -resolution- -rEFInd_directory-</code>.
 
 ### Manual installation instructions

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ This is a fork with an added readme for a description, as well as instructions f
 
 <b>2.</b> Copy this repository on your system and execute the installation script(it takes the resolution and the rEFInd directory as arguments). For example you can:
 
-<code>git clone https://github.com/dheishman/refind-dreary.git && ./refind-dreary/install.sh -resolution- -rEFInd_directory-</code>.
+<code>git clone https://github.com/dheishman/refind-dreary.git && ./refind-dreary/install.sh -resolution- -rEFInd_directory-</code>
+
+> Probably you will need to execute the installation script as root.
 
 ### Manual installation instructions
 <b>1.</b> Locate your rEFInd EFI directory. This is commonly <code>/boot/EFI/refind</code>, though it will depend on where you mount your ESP and where rEFInd is installed. <code>fdisk -l</code> and <code>mount</code> may help you find it.

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 # Installation script for the refind-dreary theme
 
 RES="$1"
+INSTALLER_DIR="$(dirname $(readlink -f $0))"
 REFIND_DIR="$2"
 DEST_DIR="${REFIND_DIR}/themes/refind-dreary"
 
@@ -28,18 +29,20 @@ if [ -d "$DEST_DIR" ]; then
 fi
 
 mkdir -p $DEST_DIR
-cp -r $RES/* $DEST_DIR
+cp -r $INSTALLER_DIR/$RES/* $DEST_DIR
 
 if [ -f "${REFIND_DIR}/refind.conf" ]; then
-    sed -i -r "s/^([[:space:]]*)(include[[:space:]]themes\/)/\1# \2/g" "${REFIND_DIR}/refind.conf"
+    sed -i -r "/^[[:space:]]*include[[:space:]]themes\/refind-dreary\/theme\.conf/!s/^([[:space:]]*)(include[[:space:]]themes\/)/\1# \2/g" "${REFIND_DIR}/refind.conf"
 else
     touch "${REFIND_DIR}/refind.conf"
 fi
 
+if ! grep -q -e "^[[:space:]]*include[[:space:]]themes/refind-dreary/theme.conf" "$REFIND_DIR/refind.conf"; then
 cat >> "${REFIND_DIR}/refind.conf" << EOF
 
 # Apply the refind-dreary theme
 include themes/refind-dreary/theme.conf
 EOF
+fi
 
 echo "Succesfully installed refind-dreary"

--- a/install.sh
+++ b/install.sh
@@ -2,28 +2,41 @@
 
 # Installation script for the refind-dreary theme
 
-destFolder="../themes/refind-dreary"
+RES="$1"
+REFIND_DIR="$2"
+DEST_DIR="${REFIND_DIR}/themes/refind-dreary"
 
 
-if ! { [ "$1" = "clover" -o "$1" = "lowres" -o "$1" = "highres" ]; }; then
+if ! { [ "$RES" = "clover" -o "$RES" = "lowres" -o "$RES" = "highres" ]; }; then
     echo "Choose a proper theme version"
     exit 1
 fi
+if [ ! -d "$2" ]; then
+    echo "Give a proper path for the rEFInd directory"
+    exit 2
+fi
 
-if [ -d "$destFolder" ]; then
-    echo "refind-dreary is already installed, would you like to reinstall it[Y/n]?"
-    read answer
+
+if [ -d "$DEST_DIR" ]; then
+    read -p "refind-dreary is already installed, would you like to reinstall it[Y/n]?" answer
     if [ "$answer" = "Y" -o "$answer" = "y" ]; then
-        rm -r "$destFolder"
+        rm -r "$DEST_DIR"
     else
         echo "Installation cancelled"
-        exit
+        exit 0
     fi
 fi
-mkdir -p $destFolder
-cp -r $1/* $destFolder
-sed -i -r "s/^[[:space:]]?include[[:space:]]themes\//# include themes\//g" ../refind.conf
-cat >> ../refind.conf << EOF
+
+mkdir -p $DEST_DIR
+cp -r $RES/* $DEST_DIR
+
+if [ -f "${REFIND_DIR}/refind.conf" ]; then
+    sed -i -r "s/^([[:space:]]*)(include[[:space:]]themes\/)/\1# \2/g" "${REFIND_DIR}/refind.conf"
+else
+    touch "${REFIND_DIR}/refind.conf"
+fi
+
+cat >> "${REFIND_DIR}/refind.conf" << EOF
 
 # Apply the refind-dreary theme
 include themes/refind-dreary/theme.conf


### PR DESCRIPTION
I find a bug that didn't let you install the theme when the install script wasn't executed within its folder.
I also documented the script and added a root privileges note on the readme.